### PR TITLE
Implement full Create Play Date Event Screen with restricted calendar selection and Firebase integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.myapplication"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.firebase.crashlytics.buildtools)
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/myapplication/AppNavigation.kt
+++ b/app/src/main/java/com/example/myapplication/AppNavigation.kt
@@ -39,10 +39,6 @@ fun AppNavigation() {
                 }
             )
         }
-
-        composable("organizerDashboard") {
-            // Screen 1.3 – Organizer Dashboard TODO
-        }
         composable("organizerDashboard") {
             OrganizerDashboardScreen(
                 onLogout = { navController.navigate("welcome") },
@@ -53,5 +49,14 @@ fun AppNavigation() {
                 onViewFeedback = { navController.navigate("viewFeedback") }
             )
         }
+        composable("createPlayDate") {
+            CreatePlayDateEventScreen(
+                onBackToDashboard = {
+                    navController.navigate("organizerDashboard")
+                }
+            )
+
+        }
     }
 }
+

--- a/app/src/main/java/com/example/myapplication/CreatePlayDateEventScreen.kt
+++ b/app/src/main/java/com/example/myapplication/CreatePlayDateEventScreen.kt
@@ -1,0 +1,379 @@
+package com.example.myapplication
+
+import android.widget.CalendarView
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun CreatePlayDateEventScreen(
+    onBackToDashboard: () -> Unit,
+    onLogout: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    val auth = FirebaseAuth.getInstance()
+    val db = FirebaseFirestore.getInstance()
+
+    // Form state
+    var playDateType by remember { mutableStateOf("") }
+    var playDateCat by remember { mutableStateOf("") }
+    var playDateTitle by remember { mutableStateOf("") }
+    var weekCommenceDate by remember { mutableStateOf("") }
+    var dayOfWeek by remember { mutableStateOf("") }
+    var selectedDate by remember { mutableStateOf("") }
+    var slotAmStart by remember { mutableStateOf("") }
+    var slotPmStart by remember { mutableStateOf("") }
+    var slotAmEnd by remember { mutableStateOf("") }
+    var slotPmEnd by remember { mutableStateOf("") }
+    var maxPlaces by remember { mutableStateOf("") }
+    var ageGroup by remember { mutableStateOf("") }
+    var specialRequirements by remember { mutableStateOf("") }
+    var showSuccessPopup by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf("") }
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    val scrollState = rememberScrollState()
+
+    fun getUpcomingMondays(): List<String> {
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())  // Use standard ISO-like format
+        val today = Calendar.getInstance()
+        val mondays = mutableListOf<String>()
+
+        val monday = today.clone() as Calendar
+        monday.set(Calendar.HOUR_OF_DAY, 0)
+        monday.set(Calendar.MINUTE, 0)
+        monday.set(Calendar.SECOND, 0)
+        monday.set(Calendar.MILLISECOND, 0)
+
+        val dow = monday.get(Calendar.DAY_OF_WEEK)
+        if (dow != Calendar.MONDAY) {
+            monday.add(Calendar.DAY_OF_MONTH, -((dow + 5) % 7))
+        }
+
+        mondays.add(format.format(monday.time))
+        for (i in 1..4) {
+            monday.add(Calendar.DAY_OF_MONTH, 7)
+            mondays.add(format.format(monday.time))
+        }
+
+        return mondays
+    }
+
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+    ) {
+        Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+            Image(
+                painter = painterResource(id = R.drawable.parentlink_logo),
+                contentDescription = null,
+                modifier = Modifier.height(50.dp)
+            )
+            Button(onClick = {
+                auth.signOut()
+                onLogout()
+            }) {
+                Text("Logout")
+            }
+        }
+
+        Text(
+            "Create a Play Date Event Screen",
+            fontSize = 20.sp,
+            modifier = Modifier.padding(vertical = 16.dp)
+        )
+
+        DropdownField(
+            "Select Play Date Type",
+            listOf("Birthday", "Fun Day", "Visiting a Place"),
+            playDateType
+        ) { playDateType = it }
+        DropdownField(
+            "Select Play Date Category",
+            listOf("Indoor", "Outdoor"),
+            playDateCat
+        ) { playDateCat = it }
+
+        OutlinedTextField(
+            value = playDateTitle,
+            onValueChange = { playDateTitle = it },
+            label = { Text("Enter Play Date Title") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        DropdownField(
+            "Select Week Commencing Date",
+            getUpcomingMondays(),
+            weekCommenceDate
+        ) { weekCommenceDate = it }
+        DropdownField(
+            "Select Day of the Week",
+            listOf("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"),
+            dayOfWeek
+        ) { dayOfWeek = it }
+
+        if (weekCommenceDate.isNotBlank()) {
+
+                val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                val parsedMonday = formatter.parse(weekCommenceDate)
+
+                parsedMonday?.let {
+                    Text("Select Date for the Play Date", fontSize = 16.sp)
+                    EmbeddedCalendar(mondayDate = it) { date ->
+                        selectedDate = date
+                    }
+                    Text("Selected Date: $selectedDate", modifier = Modifier.padding(8.dp))
+                }
+        }
+
+
+
+        DropdownField(
+            "Play Date A.M. Start Time",
+            listOf("09:00", "09:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30"),
+            slotAmStart
+        ) {
+            slotAmStart = it
+            slotPmStart = ""
+        }
+
+        if (slotAmStart.isBlank()) {
+            DropdownField(
+                "Play Date P.M. Start Time",
+                listOf(
+                    "13:00",
+                    "13:30",
+                    "14:00",
+                    "14:30",
+                    "15:00",
+                    "15:30",
+                    "16:00",
+                    "16:30",
+                    "17:00",
+                    "17:30",
+                    "18:00"
+                ),
+                slotPmStart
+            ) {
+                slotPmStart = it
+            }
+        }
+
+        if (slotAmStart.isNotBlank()) {
+            DropdownField(
+                "Play Date A.M. End Time",
+                listOf("10:00", "10:30", "11:00", "11:30", "12:00", "12:30"),
+                slotAmEnd
+            ) {
+                if (it <= slotAmStart) {
+                    errorMessage = "A.M. End Time must be after Start Time"
+                    slotAmEnd = ""
+                } else {
+                    errorMessage = ""
+                    slotAmEnd = it
+                }
+            }
+        } else if (slotPmStart.isNotBlank()) {
+            DropdownField(
+                "Play Date P.M. End Time",
+                listOf(
+                    "14:00",
+                    "14:30",
+                    "15:00",
+                    "15:30",
+                    "16:00",
+                    "16:30",
+                    "17:00",
+                    "17:30",
+                    "18:00",
+                    "18:30",
+                    "19:00"
+                ),
+                slotPmEnd
+            ) {
+                if (it <= slotPmStart) {
+                    errorMessage = "P.M. End Time must be after Start Time"
+                    slotPmEnd = ""
+                } else {
+                    errorMessage = ""
+                    slotPmEnd = it
+                }
+            }
+        }
+
+        if (errorMessage.isNotBlank()) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
+
+        OutlinedTextField(
+            value = maxPlaces,
+            onValueChange = { maxPlaces = it },
+            label = { Text("Max No of Places") },
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        DropdownField("Age Group Suitability", listOf("4-6", "7-11"), ageGroup) { ageGroup = it }
+
+        OutlinedTextField(
+            value = specialRequirements,
+            onValueChange = { specialRequirements = it },
+            label = { Text("Special Requirements (Optional)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Button(onClick = {
+            val uid = auth.currentUser?.uid
+            if (uid != null) {
+                val eventData = hashMapOf(
+                    "organizerId" to uid,
+                    "playDateTitle" to playDateTitle,
+                    "playDateType" to playDateType,
+                    "playDateCat" to playDateCat,
+                    "weekCommenceDate" to weekCommenceDate,
+                    "dayOfWeek" to dayOfWeek,
+                    "date" to selectedDate,
+                    "startTime" to (slotAmStart.ifBlank { slotPmStart }),
+                    "endTime" to (slotAmEnd.ifBlank { slotPmEnd }),
+                    "maxPlaces" to maxPlaces,
+                    "remainingPlaces" to maxPlaces,
+                    "ageGroup" to ageGroup,
+                    "specialReq" to specialRequirements.ifBlank { null },
+                    "postedDate" to SimpleDateFormat(
+                        "dd/MM/yyyy",
+                        Locale.getDefault()
+                    ).format(Date()),
+                    "postedTime" to SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
+                )
+                db.collection("Posted Play Date Event Record").add(eventData)
+                    .addOnSuccessListener { showSuccessPopup = true }
+                    .addOnFailureListener {
+                        Toast.makeText(context, "Error saving event", Toast.LENGTH_SHORT).show()
+                    }
+            }
+        }, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Save")
+        }
+
+        if (showSuccessPopup) {
+            AlertDialog(
+                onDismissRequest = { },
+                confirmButton = {},
+                title = { Text("Success") },
+                text = {
+                    Column {
+                        Text("New Record of play date event was successfully created.")
+                        Button(onClick = {
+                            playDateType = ""; playDateCat = ""; playDateTitle = ""
+                            weekCommenceDate = ""; dayOfWeek = ""; selectedDate = ""
+                            slotAmStart = ""; slotPmStart = ""; slotAmEnd = ""; slotPmEnd = ""
+                            maxPlaces = ""; ageGroup = ""; specialRequirements = ""
+                            showSuccessPopup = false
+                        }) { Text("Another Play Date Event") }
+                        Button(onClick = { onBackToDashboard() }) { Text("Back to Dashboard Screen") }
+                    }
+                }
+            )
+        }
+
+    }
+
+
+}
+
+@Composable
+fun EmbeddedCalendar(
+    mondayDate: Date,
+    onDateSelected: (String) -> Unit
+) {
+    val minCal = Calendar.getInstance().apply { time = mondayDate }
+    val maxCal = (minCal.clone() as Calendar).apply { add(Calendar.DAY_OF_MONTH, 6) }
+
+    AndroidView(
+        factory = { context ->
+            CalendarView(context).apply {
+                minDate = minCal.timeInMillis
+                maxDate = maxCal.timeInMillis
+                date = minCal.timeInMillis
+
+                setOnDateChangeListener { _, year, month, dayOfMonth ->
+                    val selectedCal = Calendar.getInstance().apply {
+                        set(year, month, dayOfMonth)
+                    }
+                    val formatted = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(selectedCal.time)
+                    onDateSelected(formatted)
+                }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+    )
+}
+
+
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DropdownField(
+    label: String,
+    options: List<String>,
+    selected: String,
+    onSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            readOnly = true,
+            value = selected,
+            onValueChange = {},
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor()
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/OrganizerDashboardScreen.kt
+++ b/app/src/main/java/com/example/myapplication/OrganizerDashboardScreen.kt
@@ -63,6 +63,7 @@ fun OrganizerDashboardScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 12.dp)
+
         ) {
             Text("Create a Play Date Event Record")
         }

--- a/app/src/main/java/com/example/myapplication/OrganizerLoginScreen.kt
+++ b/app/src/main/java/com/example/myapplication/OrganizerLoginScreen.kt
@@ -1,5 +1,6 @@
 package com.example.myapplication
 
+import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
@@ -33,7 +34,10 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.firebase.auth.FirebaseAuth
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 
+
+@SuppressLint("UseOfNonLambdaOffsetOverload")
 @Composable
 fun OrganizerLoginScreen(
     onLoginSuccess: () -> Unit = {},
@@ -45,6 +49,8 @@ fun OrganizerLoginScreen(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var loading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     val offsetY by animateDpAsState(
         targetValue = 0.dp,
@@ -100,6 +106,7 @@ fun OrganizerLoginScreen(
 
         Button(
             onClick = {
+                keyboardController?.hide()
                 if (email.isNotBlank() && password.isNotBlank()) {
                     loading = true
                     auth.signInWithEmailAndPassword(email, password)
@@ -109,11 +116,7 @@ fun OrganizerLoginScreen(
                                 Toast.makeText(context, "Login success", Toast.LENGTH_SHORT).show()
                                 onLoginSuccess()
                             } else {
-                                Toast.makeText(
-                                    context,
-                                    "Invalid email or password.",
-                                    Toast.LENGTH_LONG
-                                ).show()
+                                errorMessage = "Invalid email or password."
                             }
                         }
                 } else {
@@ -124,6 +127,14 @@ fun OrganizerLoginScreen(
             enabled = !loading
         ) {
             Text(if (loading) "Logging in..." else "Login")
+        }
+
+        if (errorMessage != null) {
+            Text(
+                text = errorMessage ?: "",
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp)
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ navigationRuntimeKtx = "2.8.9"
 appcompat = "1.7.0"
 firebaseCrashlyticsBuildtools = "3.0.3"
 firebaseAuthKtx = "23.2.0"
+firebaseFirestoreKtx = "25.1.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -37,6 +38,7 @@ androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navig
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 firebase-crashlytics-buildtools = { group = "com.google.firebase", name = "firebase-crashlytics-buildtools", version.ref = "firebaseCrashlyticsBuildtools" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
 
 
 [plugins]


### PR DESCRIPTION

- Completed Screen 1.4: Create a Play Date Event Record
- Added UI fields including:
    - Play Date Type
    - Play Date Category
    - Play Date Title
    - Week Commencing Date (dropdown with next 5 Mondays)
    - Day of the Week
    - Date Selector (only allows selection within the chosen week, starting on the selected Monday)
    - Start Time (A.M. or P.M.)
    - End Time (with validation that it must be after Start Time)
    - Max Number of Places
    - Age Group Suitability
    - Special Requirements (optional)

- Replaced previous DatePickerDialog with embedded native CalendarView using `AndroidView`
    - Calendar now restricts selection to only the week of the selected Monday
    - Prevents past date selection
    - Fixed issue where calendar showed year 1970 by switching to ISO-style `yyyy-MM-dd` for dropdown values

- On successful event creation:
    - Data is saved to Firebase Firestore under `Posted Play Date Event Record` with full event metadata
    - Shows success popup with option to create a new event or return to dashboard
    - Automatically resets form for new entry

- Code refactoring:
    - Modularized `DropdownField`
    - Implemented `EmbeddedCalendar()` for safe and localized calendar use
    - Improved error handling and UX feedback

- Fixed layout and scrollability issues for Compose UI