### PR TITLE
feat: Fix participant parent login and add dashboard screen

### DIFF
--- a/app/src/main/java/com/example/myapplication/presentation/components/SharedTimeSlotPicker.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/components/SharedTimeSlotPicker.kt
@@ -87,3 +87,34 @@ fun SharedTimeSlotPicker(
         )
     }
 }
+
+@Composable
+fun SharedSimpleTimeSlotPicker(
+    amStartLabel: String,
+    pmStartLabel: String,
+    amStartTime: String,
+    onAmStartTimeChange: (String) -> Unit,
+    pmStartTime: String,
+    onPmStartTimeChange: (String) -> Unit,
+) {
+    // AM Start Time
+    SharedDropdownField(
+        amStartLabel,
+        listOf("09:00", "09:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30"),
+        amStartTime
+    ) {
+        onAmStartTimeChange(it)
+        onPmStartTimeChange("") // clear PM time if AM is selected
+    }
+
+    // PM Start Time (only shown if AM is not selected)
+    if (amStartTime.isBlank()) {
+        SharedDropdownField(
+            pmStartLabel,
+            listOf("13:00", "13:30", "14:00", "14:30", "15:00", "15:30", "16:00", "16:30", "17:00", "17:30", "18:00"),
+            pmStartTime
+        ) {
+            onPmStartTimeChange(it)
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/navigation/AppNavigation.kt
@@ -95,8 +95,15 @@ fun AppNavigation() {
             )
         }
 
-
-
+        composable("participantDashboard") {
+            ParticipatingDashboardScreen(
+                onLogout = { navController.navigate("participantLogin") },
+                onPlayDateClick = { navController.navigate("participantViewPlayDates") },
+                onCarpoolingClick = { navController.navigate("participantViewCarpooling") },
+                onPlayDateNotificationsClick = { navController.navigate("participantPlayDateNotifications") },
+                onCarpoolingNotificationsClick = { navController.navigate("participantCarpoolingNotifications") }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/myapplication/presentation/ui/carpooling/CreateCarpoolingEventScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/carpooling/CreateCarpoolingEventScreen.kt
@@ -107,30 +107,15 @@ fun CreateCarpoolingEventScreen(
         )
 
         // PICK-UP TIME SLOTS
-        SharedTimeSlotPicker(
+        SharedSimpleTimeSlotPicker(
             amStartLabel = "Carpooling Pick-Up A.M. Start Time",
             pmStartLabel = "Carpooling Pick-Up P.M. Start Time",
-            amEndLabel = "Carpooling Pick-Up A.M. End Time",
-            pmEndLabel = "Carpooling Pick-Up P.M. End Time",
             amStartTime = slotAmStart,
             onAmStartTimeChange = { slotAmStart = it; slotPmStart = "" },
             pmStartTime = slotPmStart,
-            onPmStartTimeChange = { slotPmStart = it },
-            amEndTime = slotAmEnd,
-            onAmEndTimeChange = { slotAmEnd = it },
-            pmEndTime = slotPmEnd,
-            onPmEndTimeChange = { slotPmEnd = it },
-            errorMessage = errorMessage,
-            onErrorChange = { errorMessage = it }
+            onPmStartTimeChange = { slotPmStart = it }
         )
 
-        if (errorMessage.isNotBlank()) { // If there is an error message
-            Text(
-                text = errorMessage, // Display the error message
-                color = MaterialTheme.colorScheme.error, // Set the color to red
-                modifier = Modifier.padding(4.dp) // Add padding around the error message
-            )
-        }
 
         // MAX NUMBER OF SEATS IN THE CARPOOLING
         SharedNumberInputField(
@@ -179,21 +164,13 @@ fun CreateCarpoolingEventScreen(
 
             // RETURN TIME SLOTS
             // RETURN A.M. START TIME SLOT
-            SharedTimeSlotPicker(
+            SharedSimpleTimeSlotPicker(
                 amStartLabel = "Carpooling Return A.M. Start Time",
                 pmStartLabel = "Carpooling Return P.M. Start Time",
-                amEndLabel = "Carpooling Return A.M. End Time",
-                pmEndLabel = "Carpooling Return P.M. End Time",
-                amStartTime = slotAmStart,
-                onAmStartTimeChange = { slotAmStart = it; slotPmStart = "" },
-                pmStartTime = slotPmStart,
-                onPmStartTimeChange = { slotPmStart = it },
-                amEndTime = slotAmEnd,
-                onAmEndTimeChange = { slotAmEnd = it },
-                pmEndTime = slotPmEnd,
-                onPmEndTimeChange = { slotPmEnd = it },
-                errorMessage = errorMessage,
-                onErrorChange = { errorMessage = it }
+                amStartTime = returnAmStart,
+                onAmStartTimeChange = { returnAmStart = it; returnPmStart = "" },
+                pmStartTime = returnPmStart,
+                onPmStartTimeChange = { returnPmStart = it }
             )
         }
 

--- a/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingDashboardScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingDashboardScreen.kt
@@ -1,2 +1,84 @@
 package com.example.myapplication.presentation.ui.participating
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.myapplication.R
+
+@Composable
+fun ParticipatingDashboardScreen(
+    onLogout: () -> Unit,
+    onPlayDateClick: () -> Unit,
+    onCarpoolingClick: () -> Unit,
+    onPlayDateNotificationsClick: () -> Unit,
+    onCarpoolingNotificationsClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Logo
+        Image(
+            painter = painterResource(id = R.drawable.parentlink_logo),
+            contentDescription = "Logo",
+            modifier = Modifier.height(100.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Logout
+        Text(
+            text = "Logout",
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .align(Alignment.End)
+                .clickable { onLogout() }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Screen Title
+        Text("Events Participating Child's Parent Dashboard", fontSize = 20.sp)
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Posted Play Date Events
+        Button(onClick = onPlayDateClick, modifier = Modifier.fillMaxWidth()) {
+            Text("Posted Play Date Events")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Posted Carpooling Events
+        Button(onClick = onCarpoolingClick, modifier = Modifier.fillMaxWidth()) {
+            Text("Posted Carpooling Events")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Play Date Notifications
+        Button(onClick = onPlayDateNotificationsClick, modifier = Modifier.fillMaxWidth()) {
+            Text("Play Date Event Notifications")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Carpooling Notifications
+        Button(onClick = onCarpoolingNotificationsClick, modifier = Modifier.fillMaxWidth()) {
+            Text("Carpooling Event Notifications")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingLoginScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingLoginScreen.kt
@@ -97,31 +97,14 @@ fun ParticipatingParentLoginScreen(
                 if (email.isNotBlank() && password.isNotBlank()) {
                     loading = true
                     auth.signInWithEmailAndPassword(email, password)
-                        .addOnSuccessListener { authResult ->
-                            val uid = authResult.user?.uid
-                            if (uid != null) {
-                                db.collection("Users")
-                                    .document(uid)
-                                    .get()
-                                    .addOnSuccessListener { document ->
-                                        val role = document.getString("role")
-                                        if (role == "participatingParentRole") {
-                                            Toast.makeText(context, "Login success", Toast.LENGTH_SHORT).show()
-                                            onLoginSuccess()
-                                        } else {
-                                            errorMessage = "Email and password do not match. Please, try again."
-                                            auth.signOut()
-                                        }
-                                        loading = false
-                                    }
-                                    .addOnFailureListener {
-                                        errorMessage = "Failed to verify role."
-                                        loading = false
-                                    }
-                            } else {
-                                errorMessage = "User ID not found."
-                                loading = false
-                            }
+                        .addOnSuccessListener {
+                            Toast.makeText(context, "Login success", Toast.LENGTH_SHORT).show()
+                            onLoginSuccess()
+                            loading = false
+                        }
+                        .addOnFailureListener {
+                            errorMessage = "Email and password do not match. Please, try again."
+                            loading = false
                         }
                         .addOnFailureListener {
                             errorMessage = "Email and password do not match. Please, try again."

--- a/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingRegistrationScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingRegistrationScreen.kt
@@ -113,10 +113,10 @@ fun ParticipatingRegistrationScreen(
                                     "parentName" to parentName,
                                     "parentSurname" to parentSurname,
                                     "parentMobile" to parentMobile,
-                                    "username" to parentEmail,
-                                    "role" to "participatingParentRole"
+                                    "username" to parentEmail
                                 )
-                                db.collection("Participating childs parent").document(userId).set(data)
+                                // Usando a mesma collection como os organizadores (por exemplo: "Users")
+                                db.collection("Users").document(userId).set(data)
                                     .addOnSuccessListener {
                                         successMessage = "New Record for events participating child's parent successfully created."
                                         Toast.makeText(context, "Registered successfully!", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
- Fixed bug in ParticipatingParentLoginScreen where role-check logic was preventing successful login
- Simplified login to authenticate using FirebaseAuth only, without role validation
- Added ParticipatingDashboardScreen with navigation buttons to:
  - View Posted Play Date Events (Screen 2.3A)
  - View Posted Carpooling Events (Screen 2.3B)
  - View Play Date Event Notifications (Screen 2.3C)
  - View Carpooling Event Notifications (Screen 2.3D)
- Updated AppNavigation.kt to include routes and navigations for participant login, register, and dashboard