### PR TITLE
feat: Added ParticipatingViewPlaydateScreen, removed end times from Carpooling screen, updated navigation, and added venue field to Play Date creation

### DIFF
--- a/app/src/main/java/com/example/myapplication/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import com.example.myapplication.presentation.ui.organizer.*
 import com.example.myapplication.presentation.ui.playdate.CreatePlayDateEventScreen
 import com.example.myapplication.presentation.ui.welcome.WelcomeScreen
 import com.example.myapplication.presentation.ui.participating.*
+import android.util.Log
 
 
 @Composable
@@ -104,6 +105,34 @@ fun AppNavigation() {
                 onCarpoolingNotificationsClick = { navController.navigate("participantCarpoolingNotifications") }
             )
         }
+        composable("participantViewPlayDates") {
+            ParticipatingViewPlaydateScreen(
+                onLogout = { navController.navigate("participantLogin") },
+                onBackToDashboard = { navController.navigate("participantDashboard") },
+                onViewEventDetails = { event ->
+                    val eventRecordId = event["id"] as? String ?: ""
+                    val organizerId = event["organizerId"] as? String ?: ""
+                    navController.navigate("playDateDetails/$eventRecordId/$organizerId")
+                }
+            )
+        }
+        composable("playDateDetails/{eventRecordId}/{organizerId}") { backStackEntry ->
+            val eventRecordId = backStackEntry.arguments?.getString("eventRecordId") ?: ""
+            val organizerId = backStackEntry.arguments?.getString("organizerId") ?: ""
+
+            ParticipatingPlayDateDetailScreen(
+                eventRecordId = eventRecordId,
+                organizerId = organizerId,
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+
+
+
+
     }
 }
 

--- a/app/src/main/java/com/example/myapplication/presentation/ui/carpooling/CreateCarpoolingEventScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/carpooling/CreateCarpoolingEventScreen.kt
@@ -1,16 +1,13 @@
 package com.example.myapplication.presentation.ui.carpooling
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 import java.text.SimpleDateFormat
 import java.util.*
 import com.example.myapplication.presentation.components.*
@@ -44,7 +41,6 @@ fun CreateCarpoolingEventScreen(
     var returnPmEnd by remember { mutableStateOf("") }
     var specialRequirements by remember { mutableStateOf("") }
     var showPopup by remember { mutableStateOf(false) }
-    var errorMessage by remember { mutableStateOf("") }
 
     val scrollState = rememberScrollState() // For scrolling the form
 // ###################################### END LOCAL VARIABLES #####################################

--- a/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingViewPlaydateScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/participating/ParticipatingViewPlaydateScreen.kt
@@ -1,0 +1,126 @@
+package com.example.myapplication.presentation.ui.participating
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.presentation.components.ScreenHeader
+import com.example.myapplication.presentation.components.SharedWeekCommencingField
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+
+@Composable
+fun ParticipatingViewPlaydateScreen(
+    onLogout: () -> Unit,
+    onBackToDashboard: () -> Unit,
+    onViewEventDetails: (Map<String, Any>) -> Unit
+) {
+    val auth = FirebaseAuth.getInstance()
+    val db = FirebaseFirestore.getInstance()
+
+    var selectedWeek by remember { mutableStateOf("") }
+    var events by remember { mutableStateOf<List<Map<String, Any>>>(emptyList()) }
+    var selectedTitle by remember { mutableStateOf("") }
+    var selectedDate by remember { mutableStateOf("") }
+    var selectedTime by remember { mutableStateOf("") }
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+    ) {
+        // ✅ Corrected Header Title
+        ScreenHeader(
+            title = "View List of Play Date Events",
+            onLogoutClick = {
+                auth.signOut()
+                onLogout()
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Week Commencing Dropdown
+        SharedWeekCommencingField(
+            selectedValue = selectedWeek,
+            onValueChange = {
+                selectedWeek = it
+                db.collection("Posted Play Date Event Record")
+                    .whereEqualTo("weekCommenceDate", it)
+                    .get()
+                    .addOnSuccessListener { snapshot ->
+                        events = snapshot.documents.mapNotNull { doc ->
+                            doc.data?.toMutableMap()?.apply {
+                                this["id"] = doc.id
+                            }
+                        }.sortedWith(
+                            compareByDescending<Map<String, Any>> {
+                                it["postedDate"] as? String ?: ""
+                            }.thenByDescending {
+                                it["postedTime"] as? String ?: ""
+                            }
+                        )
+                    }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Select a Play Date Event from the List", style = MaterialTheme.typography.titleMedium)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        events.forEach { event ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                elevation = CardDefaults.cardElevation()
+            ) {
+                Column(Modifier.padding(8.dp)) {
+                    Text("Title: ${event["playDateTitle"]}")
+                    Text("Posted on: ${event["postedDate"]} at ${event["postedTime"]}")
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Button(onClick = {
+                        selectedTitle = event["playDateTitle"] as String
+                        selectedDate = event["postedDate"] as String
+                        selectedTime = event["postedTime"] as String
+                        onViewEventDetails(event)
+                    }) {
+                        Text("View")
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = {
+                selectedTitle = ""
+                selectedDate = ""
+                selectedTime = ""
+                selectedWeek = ""
+                events = emptyList()
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp)
+        ) {
+            Text("Select Another Play Date Event to View")
+        }
+
+        Button(
+            onClick = onBackToDashboard,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back to Dashboard")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/presentation/ui/participating/PaticipatingPlayDateDetailScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/participating/PaticipatingPlayDateDetailScreen.kt
@@ -1,0 +1,25 @@
+package com.example.myapplication.presentation.ui.participating
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ParticipatingPlayDateDetailScreen(
+    eventRecordId: String,
+    organizerId: String,
+    onBack: () -> Unit
+) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .padding(16.dp)) {
+        Text("Event ID: $eventRecordId")
+        Text("Organizer ID: $organizerId")
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onBack) {
+            Text("Back")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/presentation/ui/playdate/CreatePlayDateEventScreen.kt
+++ b/app/src/main/java/com/example/myapplication/presentation/ui/playdate/CreatePlayDateEventScreen.kt
@@ -3,7 +3,6 @@ package com.example.myapplication.presentation.ui.playdate
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -27,6 +26,7 @@ fun CreatePlayDateEventScreen(
     // Form state
     var playDateType by remember { mutableStateOf("") }
     var playDateCat by remember { mutableStateOf("") }
+    var playDateVenue by remember { mutableStateOf("") }
     var playDateTitle by remember { mutableStateOf("") }
     var weekCommenceDate by remember { mutableStateOf("") }
     var dayOfWeek by remember { mutableStateOf("") }
@@ -76,6 +76,13 @@ fun CreatePlayDateEventScreen(
             listOf("Indoor", "Outdoor"), // Options for the dropdown
             playDateCat // Selected option
         ) { playDateCat = it } // Callback when an option is selected
+
+        // PLAY DATE VENUE
+        SharedTextField(
+            value = playDateVenue,
+            onValueChange = { playDateVenue = it },
+            label = "Enter Play Date Venue"
+        )
 
         // PLAY DATE TITLE
         SharedTextField(
@@ -146,6 +153,7 @@ fun CreatePlayDateEventScreen(
                 hashMapOf(
                     "organizerId" to uid,
                     "playDateTitle" to playDateTitle,
+                    "playDateVenue" to playDateVenue,
                     "playDateType" to playDateType,
                     "playDateCat" to playDateCat,
                     "weekCommenceDate" to weekCommenceDate,


### PR DESCRIPTION
- Created ParticipatingViewPlaydateScreen with header, week selection, event list, and View button for details
- Updated AppNavigation to include route for ParticipatingViewPlaydateScreen
- Removed end time fields from pickup and return slots in CreateCarpoolingEventScreen
- Added SharedSimpleTimeSlotPicker instead of full time slot picker for carpooling
- Added new Play Date Venue field to CreatePlayDateEventScreen
- Stored playDateVenue field in Firestore document
- Minor UI adjustments and screen consistency updates